### PR TITLE
added robertkennedy aoc 2019 01-09

### DIFF
--- a/src/aoc/2019/robertkennedy/01.hs
+++ b/src/aoc/2019/robertkennedy/01.hs
@@ -1,0 +1,12 @@
+module Main where
+
+main = do
+    masses <- map read . lines <$> readFile "01.txt"
+    print $ sum $ map massToFuel masses
+    print $ sum $ map totalFuelReq masses
+
+massToFuel :: Int -> Int
+massToFuel n = max 0 $ n `div` 3 - 2
+
+totalFuelReq :: Int -> Int
+totalFuelReq = sum . takeWhile (>0) . tail . iterate massToFuel

--- a/src/aoc/2019/robertkennedy/02.hs
+++ b/src/aoc/2019/robertkennedy/02.hs
@@ -1,0 +1,52 @@
+module Main where
+
+import Data.Function
+import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as VM
+
+main = do
+    input <- read . (\s -> "["++s++"]") <$> readFile "02.txt"
+    print $ p1 input
+    print $ p2 input
+    
+p1 :: V.Vector Int -> Int
+p1 = run 12 2
+
+p2 :: V.Vector Int -> Int
+p2 vec = head
+    [ 100*n+v
+    | n <- [0..99]
+    , v <- [0..99]
+    , run n v vec == 19690720
+    ]
+
+run :: Int -> Int -> V.Vector Int -> Int
+run noun verb = V.head . currVec . last . iterateMaybe step . State 0 . writeAt 2 verb . writeAt 1 noun
+
+data State = State 
+   { nextIndex :: {-# unpack #-} !Int
+   , currVec   :: !(V.Vector Int)
+   } deriving (Eq,Show)
+   
+-- Intcode 
+step :: State -> Maybe State
+step (State i v) = case v V.! i of
+    1  -> Just $
+        let a = v V.! (v V.! (i+1))
+            b = v V.! (v V.! (i+2))
+            c = v V.! (i+3)
+         in State (i+4) (writeAt c (b+a) v)
+    2  -> Just $
+        let a = v V.! (v V.! (i+1))
+            b = v V.! (v V.! (i+2))
+            c = v V.! (i+3)
+         in State (i+4) (writeAt c (b*a) v)
+    99 -> Nothing
+    val -> error $ "Unrecognized value: " ++ show val
+    
+    
+writeAt :: Int -> a -> V.Vector a -> V.Vector a
+writeAt i value = V.modify $ \vec -> VM.write vec i value
+
+iterateMaybe :: (a -> Maybe a) -> a -> [a]
+iterateMaybe f = fix $ \rec x -> x : maybe [] rec (f x)

--- a/src/aoc/2019/robertkennedy/03.hs
+++ b/src/aoc/2019/robertkennedy/03.hs
@@ -1,0 +1,94 @@
+{-# language OverloadedStrings #-}
+{-# language BangPatterns #-}
+module Main where
+
+import Control.Applicative
+import Control.Lens
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.List
+
+import Data.Attoparsec.Text hiding (D,take)
+import Data.Text (Text)
+import qualified Data.Text as T
+
+main = do
+    (a,b) <- getInput
+    print $ p1 a b
+    print $ p2 a b
+    
+p1 :: [Move] -> [Move] -> Int
+p1 a b = let sa = visitedSquares a; sb = visitedSquares b
+             comm = sa `Set.intersection` sb
+             dists = Set.map (\(x,y) -> abs x + abs y) comm
+          in Set.findMin dists
+p2 :: [Move] -> [Move] -> Int
+p2 a b = let sa = signalDelays a; sb = signalDelays b
+             dists = Map.intersectionWith (+) sa sb
+          in minimum $ Map.elems dists
+
+
+
+visitedSquares :: [Move] -> Set Coord
+visitedSquares = fst . Data.List.foldl' (uncurry go) (mempty,(0,0))
+    where
+    go :: Set Coord -> Coord -> Move -> (Set Coord, Coord)
+    go !acc !coord (dir,d) =
+        let visits = take d $ tail $ iterate (move dir) coord
+         in (acc <> Set.fromList visits,last visits)
+    
+signalDelays :: [Move] -> Map Coord Int
+signalDelays = fst . Data.List.foldl' go (mempty,((0,0),0))
+    where
+    go :: (Map Coord Int, (Coord, Int)) -> Move -> (Map Coord Int, (Coord, Int))
+    go (!acc,pos) (dir,d) =
+        let visits = take d $ tail $ iterate (over _1 (move dir) . over _2 succ) pos
+         in (acc <> Map.fromList visits,last visits)
+    
+    
+type Move = (Dir,Int)
+type Coord = (Int,Int)
+data Dir = U | L | R | D deriving (Eq, Show, Ord)
+move :: Dir -> Coord -> Coord
+move dir = case dir of 
+    U -> _2 %~ succ
+    L -> _1 %~ pred
+    R -> _1 %~ succ
+    D -> _2 %~ pred
+    
+moveBy :: Dir -> Int -> Coord -> Coord
+moveBy dir d = case dir of 
+    U -> _2 %~ (+d)
+    L -> _1 %~ (subtract d)
+    R -> _1 %~ (+d)
+    D -> _2 %~ (subtract d)
+    
+
+    
+    
+    
+getInput :: IO (Line,Line)
+getInput = readFile "03.txt"
+      >>= either fail return . parseOnly (parseInput <* skipSpace <* endOfInput) . T.pack
+    
+parseInput :: Parser (Line,Line)
+parseInput = (,) <$> (parseLine <* skipSpace) <*> parseLine
+    
+type Line = [Move]
+parseLine :: Parser Line
+parseLine = sepBy1' parseMove (char ',')
+
+parseMove :: Parser Move
+parseMove = (,) <$> parseDir <*> decimal
+
+parseDir :: Parser Dir
+parseDir = U <$ char 'U'
+       <|> L <$ char 'L'
+       <|> R <$ char 'R'
+       <|> D <$ char 'D'
+    
+
+    
+ex = "R75,D30,R83,U83,L12,D49,R71,U7,L72\nU62,R66,U55,R34,D71,R55,D58,R83"

--- a/src/aoc/2019/robertkennedy/04.hs
+++ b/src/aoc/2019/robertkennedy/04.hs
@@ -1,0 +1,32 @@
+{-# language OverloadedStrings #-}
+{-# language BangPatterns #-}
+module Main where
+
+import Control.Applicative
+import Control.Lens
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.List
+
+main = do
+    putStrLn "Hello World"
+    print $ length $ filter hasDouble $ possibles
+    print $ length $ filter good $ possibles
+    
+    
+hasDouble :: Eq a => [a] -> Bool
+hasDouble l = any (uncurry (==)) $ zip l (tail l)
+
+good (a:b:c:ds) 
+    | a == b && b /= c = True
+    | a == b = good $ dropWhile (==a) ds
+    | otherwise = good (b:c:ds)
+good [a,b] = a == b
+good _ = False
+    
+gen 1 c = [[c]]
+gen n c = map (c:) $ foldMap (gen (n-1)) [c..'9']
+
+possibles = takeWhile (<="676461") $ dropWhile (<"178416") $ foldMap (gen 6) ['1'..'9']

--- a/src/aoc/2019/robertkennedy/05.hs
+++ b/src/aoc/2019/robertkennedy/05.hs
@@ -1,0 +1,146 @@
+{-# language OverloadedStrings #-}
+{-# language BangPatterns #-}
+{-# language LambdaCase #-} 
+-- {-# language TemplateHaskell #-}
+module Main where
+
+import Control.Lens
+import Data.Function
+import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as VM
+
+
+main :: IO ()
+main = do
+    dat <- read . (\s -> "["++s++"]") <$> readFile "05.txt"
+    print $ prob 1 dat
+    print $ prob 5 dat
+    
+prob :: Int -> V.Vector Int -> Int
+prob num = head . _outputs . last . steps num
+
+steps :: Int -> V.Vector Int -> [State]
+steps num = iterateMaybe step . State num [] 0
+
+-- * Intcode 
+data State = State 
+   { _input     :: {-# unpack #-} !Int
+   , _outputs   :: ![Int]
+   , _nextIndex :: {-# unpack #-} !Int
+   , _currVector:: !(V.Vector Int)
+   } deriving (Eq,Show,Read)
+   
+data ParameterMode = Position | Immediate 
+     deriving (Eq,Ord,Show,Enum,Bounded)
+
+readParameterMode :: Int -> ParameterMode
+readParameterMode 0 = Position
+readParameterMode 1 = Immediate
+readParameterMode n = error $ "Unrecognized ParameterMode: " ++ show n
+
+data Opcode =
+     Add  ParameterMode ParameterMode 
+   | Mult ParameterMode ParameterMode 
+   | Stop
+   | Input
+   | Output ParameterMode
+   | JumpIfTrue  ParameterMode ParameterMode
+   | JumpIfFalse ParameterMode ParameterMode
+   | LessThan    ParameterMode ParameterMode
+   | Equals      ParameterMode ParameterMode
+     deriving (Eq,Ord,Show)
+
+readOpcode :: Int -> Opcode
+readOpcode n = let (pms,opc) = n `divMod` 100 in case opc of
+    1  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in Add  (readParameterMode a) (readParameterMode b)
+    2  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in Mult (readParameterMode a) (readParameterMode b)
+    3  -> Input
+    4  -> let (_,a) = pms `divMod` 10 in Output (readParameterMode a)
+    5  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in JumpIfTrue  (readParameterMode a) (readParameterMode b)
+    6  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in JumpIfFalse (readParameterMode a) (readParameterMode b)
+    7  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in LessThan    (readParameterMode a) (readParameterMode b)
+    8  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in Equals      (readParameterMode a) (readParameterMode b)
+    99 -> Stop
+    _ -> error $ "Unrecognized Opcode: " ++ show n
+
+runOp :: State -> Opcode -> Maybe State
+runOp s = \case 
+    Add  p1 p2 -> Just $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+            j = getVal Immediate (i+3) vec
+         in writeAt j (a + b)
+    Mult p1 p2 -> Just $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+            j = getVal Immediate (i+3) vec
+         in writeAt j (a * b)
+    Input -> Just $ s & nextIndex %~ (+2) & currVector %~ 
+        let j = getVal Immediate (i+1) vec
+         in writeAt j (s ^. input)
+    Output p1 -> Just $ s & nextIndex %~ (+2) & outputs %~ ((getVal p1 (i+1) $ s ^. currVector):)
+    JumpIfTrue p1 p2 -> Just $ s & nextIndex %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+         in if a /= 0 then const b else (+3)
+    JumpIfFalse p1 p2 -> Just $ s & nextIndex %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+         in if a == 0 then const b else (+3)
+    LessThan p1 p2 -> Just $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+            j = getVal Immediate (i+3) vec
+         in writeAt j (if a < b then 1 else 0)
+    Equals p1 p2 -> Just $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+            j = getVal Immediate (i+3) vec
+         in writeAt j (if a == b then 1 else 0)
+    Stop  -> Nothing
+    where
+    i = s ^. nextIndex
+    vec = s ^. currVector
+    
+getVal :: ParameterMode -> Int -> V.Vector Int -> Int
+getVal Immediate i v = v V.! i
+getVal Position i v = v V.! (v V.! i)
+    
+getOp :: State -> Opcode
+getOp s = readOpcode $ (s ^. currVector) V.! (s ^. nextIndex)
+   
+step :: State -> Maybe State
+step s = runOp s $ readOpcode $ (s ^. currVector) V.! (s ^. nextIndex)
+    
+-- * Utils    
+writeAt :: Int -> a -> V.Vector a -> V.Vector a
+writeAt i value = V.modify $ \vec -> VM.write vec i value
+
+iterateMaybe :: (a -> Maybe a) -> a -> [a]
+iterateMaybe f = fix $ \rec x -> x : maybe [] rec (f x)
+
+
+-- * Lenses
+-- :set -ddump-splices
+-- makeLenses ''State
+
+currVector :: Lens' State (V.Vector Int)
+currVector f_aNEn (State x1_aNEo x2_aNEp x3_aNEq x4_aNEr)
+  = (fmap (\ y1_aNEs -> (((State x1_aNEo) x2_aNEp) x3_aNEq) y1_aNEs))
+      (f_aNEn x4_aNEr)
+{-# INLINE currVector #-}
+input :: Lens' State Int
+input f_aNEt (State x1_aNEu x2_aNEv x3_aNEw x4_aNEx)
+  = (fmap (\ y1_aNEy -> (((State y1_aNEy) x2_aNEv) x3_aNEw) x4_aNEx))
+      (f_aNEt x1_aNEu)
+{-# INLINE input #-}
+nextIndex :: Lens' State Int
+nextIndex f_aNEz (State x1_aNEA x2_aNEB x3_aNEC x4_aNED)
+  = (fmap (\ y1_aNEE -> (((State x1_aNEA) x2_aNEB) y1_aNEE) x4_aNED))
+      (f_aNEz x3_aNEC)
+{-# INLINE nextIndex #-}
+outputs :: Lens' State [Int]
+outputs f_aNEF (State x1_aNEG x2_aNEH x3_aNEI x4_aNEJ)
+  = (fmap (\ y1_aNEK -> (((State x1_aNEG) y1_aNEK) x3_aNEI) x4_aNEJ))
+      (f_aNEF x2_aNEH)
+{-# INLINE outputs #-}

--- a/src/aoc/2019/robertkennedy/06.hs
+++ b/src/aoc/2019/robertkennedy/06.hs
@@ -1,0 +1,47 @@
+{-# language DeriveFunctor #-}
+{-# language DeriveTraversable #-}
+module Main where
+
+import Control.Applicative
+import Control.Monad
+import Control.Lens
+import Data.Foldable
+import qualified Data.List
+
+main = do
+    v <-getInput 
+    print $ sum $ depths $ fromList "COM" v
+    print $ p2 $ fromList "COM" v
+    
+p2 :: Orbits String -> Maybe Int
+p2 s@(HasOrbits "SAN" _) = getDepth "YOU" s
+p2 s@(HasOrbits "YOU" _) = getDepth "SAN" s
+p2 s@(HasOrbits _ os) = case Data.Foldable.find (\o -> any (=="SAN") o && any (=="YOU") o) os of
+    Nothing -> fmap (subtract 2) $ (+) <$> getDepth "SAN" s <*> getDepth "YOU" s
+    Just o -> p2 o
+    
+data Orbits a = Node a | HasOrbits a [Orbits a] deriving (Eq, Show, Functor, Foldable)
+zipOrbits (Node x) (Node y) = Node (x,y)
+zipOrbits (HasOrbits x xs) (HasOrbits y ys) = HasOrbits (x,y) (zipWith zipOrbits xs ys)
+
+depths :: Orbits n -> Orbits Int
+depths (Node _) = Node 0
+depths (HasOrbits _ o) = HasOrbits 0 $ map (fmap succ . depths) o
+
+getDepth :: Eq n => n -> Orbits n -> Maybe Int
+getDepth n s = let ts = zipOrbits s (depths s) in fmap snd $ Data.Foldable.find ((==n) . fst) ts
+    
+-- * Input
+getInput = parseInput <$> readFile "06.txt"
+parseInput = map parseLine . filter (not . null) . lines
+parseLine :: String -> (String,String)
+parseLine [a,b,c,')',d,e,f] = ([a,b,c],[d,e,f])
+
+fromList :: Eq a => a -> [(a, a)] -> Orbits a
+fromList name ls =
+    let (a,b) = Data.List.partition ((==name) . fst) ls
+     in if null a then Node name else HasOrbits name $ map ((`fromList` b) . snd) a
+
+-- * Util
+ex = "COM)B01\nB01)C01\nC01)D01\nD01)E01\nE01)F01\nB01)G01\nG01)H01\nD01)I01\nE01)J01\nJ01)K01\nK01)L01"
+ex2 = "COM)B01\nB01)C01\nC01)D01\nD01)E01\nE01)F01\nB01)G01\nG01)H01\nD01)I01\nE01)J01\nJ01)K01\nK01)L01\nK01)YOU\nI01)SAN"

--- a/src/aoc/2019/robertkennedy/07.hs
+++ b/src/aoc/2019/robertkennedy/07.hs
@@ -1,0 +1,179 @@
+{-# language OverloadedStrings #-}
+{-# language BangPatterns #-}
+{-# language LambdaCase #-} 
+{-# language TupleSections #-} 
+-- {-# language TemplateHaskell #-}
+module Main where
+
+import Control.Lens
+import Data.Foldable
+import Data.Function
+import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as VM
+import qualified Data.List
+
+
+main :: IO ()
+main = do
+    dat <- read . (\s -> "["++s++"]") <$> readFile "07.txt"
+    print $ p1 dat
+    print $ p2 dat
+    
+p1 :: V.Vector Int -> Int
+p1 vec = maximum $ map (runP1 vec) $ Data.List.permutations [0..4]
+    
+runP1 :: V.Vector Int -> [Int] -> Int
+runP1 v = foldl' go 0
+    where
+    -- go !o i = getOutput [i,o] v
+    go !o i = case runToPause $ State 0 v of
+        NeedsInput f -> case runToPause $ f i of
+            NeedsInput f' -> case runToPause $ f' o of
+                HasOutput (out,_) -> out
+        
+p2 :: V.Vector Int -> Int
+p2 vec = maximum $ map (runP2 vec) $ Data.List.permutations [5..9]
+
+runP2 :: V.Vector Int -> [Int] -> Int
+runP2 v = go . alterHead . feedInputs . zip (replicate 5 $ runToPause $ State 0 v) . map pure
+    where
+    alterHead ((NeedsInput f,[]):ss) = (runToPause $ f 0,[]):ss
+    
+    rotate (a:ss) = ss++[a]
+    feedOutput ((HasOutput(o,s),is):(b,is'):ss) = (runToPause s,is):(b,is'++[o]):ss
+    feedOutput ss = ss
+    
+    feedInput (NeedsInput f) (i:is) = (runToPause (f i),is)
+    feedInput pr ins = (pr,ins)
+    
+    feedOutputs = foldr (.) id $ replicate 5 (rotate.feedOutput)
+    feedInputs = map $ uncurry feedInput
+    
+    go ss = if all (isStopped.fst) ss then head $ snd $ head ss else go $ feedInputs $ feedOutputs $ ss
+
+-- * Intcode 
+data State = State 
+   { _nextIndex :: {-# unpack #-} !Int
+   , _currVector:: !(V.Vector Int)
+   } deriving (Eq,Show,Read)
+   
+data ParameterMode = Position | Immediate 
+     deriving (Eq,Ord,Show,Enum,Bounded)
+
+readParameterMode :: Int -> ParameterMode
+readParameterMode 0 = Position
+readParameterMode 1 = Immediate
+readParameterMode n = error $ "Unrecognized ParameterMode: " ++ show n
+
+getVal :: ParameterMode -> Int -> V.Vector Int -> Int
+getVal Immediate i v = v V.! i
+getVal Position i v = v V.! (v V.! i)
+
+data Opcode =
+     Add  ParameterMode ParameterMode 
+   | Mult ParameterMode ParameterMode 
+   | Stop
+   | Input
+   | Output ParameterMode
+   | JumpIfTrue  ParameterMode ParameterMode
+   | JumpIfFalse ParameterMode ParameterMode
+   | LessThan    ParameterMode ParameterMode
+   | Equals      ParameterMode ParameterMode
+     deriving (Eq,Ord,Show)
+
+readOpcode :: Int -> Opcode
+readOpcode n = let (pms,opc) = n `divMod` 100 in case opc of
+    1  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in Add  (readParameterMode a) (readParameterMode b)
+    2  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in Mult (readParameterMode a) (readParameterMode b)
+    3  -> Input
+    4  -> let (_,a) = pms `divMod` 10 in Output (readParameterMode a)
+    5  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in JumpIfTrue  (readParameterMode a) (readParameterMode b)
+    6  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in JumpIfFalse (readParameterMode a) (readParameterMode b)
+    7  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in LessThan    (readParameterMode a) (readParameterMode b)
+    8  -> let (r,a) = pms `divMod` 10; (_,b) = r `divMod` 10 in Equals      (readParameterMode a) (readParameterMode b)
+    99 -> Stop
+    _ -> error $ "Unrecognized Opcode: " ++ show n
+
+data PauseReason = 
+     Stopped 
+   | NeedsInput (Int -> State) 
+   | HasOutput (Int,State)
+   
+isStopped :: PauseReason -> Bool
+isStopped Stopped = True
+isStopped _ = False
+    
+runOp :: State -> Opcode -> Either PauseReason State
+runOp s = \case 
+    Add  p1 p2 -> Right $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+            j = getVal Immediate (i+3) vec
+         in writeAt j (a + b)
+    Mult p1 p2 -> Right $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+            j = getVal Immediate (i+3) vec
+         in writeAt j (a * b)
+    JumpIfTrue p1 p2 -> Right $ s & nextIndex %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+         in if a /= 0 then const b else (+3)
+    JumpIfFalse p1 p2 -> Right $ s & nextIndex %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+         in if a == 0 then const b else (+3)
+    LessThan p1 p2 -> Right $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+            j = getVal Immediate (i+3) vec
+         in writeAt j (if a < b then 1 else 0)
+    Equals p1 p2 -> Right $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal p1 (i+1) vec
+            b = getVal p2 (i+2) vec
+            j = getVal Immediate (i+3) vec
+         in writeAt j (if a == b then 1 else 0)
+    Input -> Left $ NeedsInput $ \input -> 
+                s & nextIndex %~ (+2) & currVector %~ 
+                    let j = getVal Immediate (i+1) vec
+                     in writeAt j input
+    Output p1 -> Left $ HasOutput 
+                ( getVal p1 (i+1) $ s ^. currVector
+                , s & nextIndex %~ (+2)
+                )
+    Stop  -> Left Stopped
+    where
+    i = s ^. nextIndex
+    vec = s ^. currVector
+    
+getOp :: State -> Opcode
+getOp s = readOpcode $ (s ^. currVector) V.! (s ^. nextIndex)
+   
+step :: State -> Either PauseReason State
+step s = runOp s $ getOp s
+
+runToPause :: State -> PauseReason
+runToPause = either id runToPause . step 
+    
+-- * Utils    
+writeAt :: Int -> a -> V.Vector a -> V.Vector a
+writeAt i value = V.modify $ \vec -> VM.write vec i value
+
+iterateMaybe :: (a -> Maybe a) -> a -> [a]
+iterateMaybe f = fix $ \rec x -> x : maybe [] rec (f x)
+
+
+-- * Lenses
+-- :set -ddump-splices
+-- makeLenses ''State
+
+currVector :: Lens' State (V.Vector Int)
+currVector f_a1hCW (State x1_a1hCX x2_a1hCY)
+  = (fmap (\ y1_a1hCZ -> (State x1_a1hCX) y1_a1hCZ))
+      (f_a1hCW x2_a1hCY)
+{-# INLINE currVector #-}
+nextIndex :: Lens' State Int
+nextIndex f_a1hD0 (State x1_a1hD1 x2_a1hD2)
+  = (fmap (\ y1_a1hD3 -> (State y1_a1hD3) x2_a1hD2))
+      (f_a1hD0 x1_a1hD1)
+{-# INLINE nextIndex #-}

--- a/src/aoc/2019/robertkennedy/08.hs
+++ b/src/aoc/2019/robertkennedy/08.hs
@@ -1,0 +1,66 @@
+{-# language OverloadedStrings #-}
+{-# language BangPatterns #-}
+{-# language DeriveFunctor #-}
+{-# language DeriveTraversable #-}
+{-# language TransformListComp #-}
+module Main where
+
+import Control.Applicative
+import Control.Monad
+import Control.Lens
+import Data.Char
+import Data.Ord
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.List
+import Data.Array.Unboxed as UArray
+import GHC.Exts (groupWith,the)
+
+main = do
+    is <- map digitToInt . filter isDigit <$> readFile "08.txt" 
+    let arr = buildArr 25 6 is
+    print $ checkDigit arr
+    putStrLn $ drawImage $ flatten arr
+    
+checkDigit :: UArray (Int,Int,Int) Int -> Maybe Int
+checkDigit arr = 
+    let layer = head $ Data.List.sortOn (lookup 0) $ map (count . layerElems) [t0..t1]
+     in (*) <$> lookup 1 layer <*> lookup 2 layer
+    where
+    ((t0,h0,w0),(t1,h1,w1)) = bounds arr
+    counts = count . layerElems
+    layerElems t = map (\(x,y) -> arr ! (t,x,y)) $ range ((h0,w0),(h1,w1))
+    
+
+flatten :: UArray (Int,Int,Int) Int -> UArray (Int,Int) Bool
+flatten arr = array ((h0,w0),(h1,w1)) $ map go $ range ((h0,w0),(h1,w1))
+    where
+    ((t0,h0,w0),(t1,h1,w1)) = bounds arr
+    go (y,x) = ((y,x), (==1) $ head $ dropWhile (==2) $ map (\t -> arr ! (t,y,x)) [t0..t1])
+    
+drawImage :: UArray (Int,Int) Bool -> String
+drawImage arr = unlines
+    [[if arr!(y,x) then ' ' else blockChar |x <-[w0..w1]]
+    |y <-[h0..h1]
+    ]
+    where
+    ((h0,w0),(h1,w1)) = bounds arr
+    
+    
+buildArr :: Int -> Int -> [Int] -> UArray (Int,Int,Int) Int
+buildArr w h is = listArray ((1,1,1),(t,h,w)) is
+    where t = length is `div` h `div` w
+    
+buildArrS :: Int -> Int -> String -> UArray (Int,Int,Int) Int
+buildArrS w h = buildArr w h . map digitToInt . filter isDigit
+
+count :: Ord a => [a] -> [(a,Int)]
+count xs = 
+    [ (the x,length x)
+    | x <- xs
+    , then group by x using groupWith
+    ]
+    
+blockChar = '█'

--- a/src/aoc/2019/robertkennedy/09.hs
+++ b/src/aoc/2019/robertkennedy/09.hs
@@ -1,0 +1,198 @@
+{-# language OverloadedStrings #-}
+{-# language BangPatterns #-}
+{-# language LambdaCase #-} 
+{-# language TupleSections #-} 
+-- {-# language TemplateHaskell #-}
+module Main where
+
+import Control.Lens
+import Data.Foldable
+import Data.Function
+import Data.Maybe
+import qualified Data.Vector as V
+import qualified Data.Vector.Mutable as VM
+import qualified Data.List
+
+main :: IO ()
+main = do
+    dat <- read . (\s -> "["++s++"]") <$> readFile "09.txt" :: IO (V.Vector Int)
+    print $ p1 dat
+    print $ p2 dat
+    
+p1 :: V.Vector Int -> [Int]
+p1 = go . runToPause . State 0 0
+    where
+    go = \case
+        Stopped -> []
+        HasOutput(o,s)->o:go (runToPause s)
+        NeedsInput f -> go (runToPause $ f 1)
+p2 :: V.Vector Int -> [Int]
+p2 = go . runToPause . State 0 0
+    where
+    go = \case
+        Stopped -> []
+        HasOutput(o,s)->o:go (runToPause s)
+        NeedsInput f -> go (runToPause $ f 2)
+
+testInputs :: V.Vector Int -> [Int]
+testInputs = go . runToPause . State 0 0
+    where
+    go = \case
+        Stopped -> []
+        HasOutput(o,s)->o:go (runToPause s)
+
+-- * Intcode 
+data State = State 
+   { _nextIndex    :: {-# unpack #-} !Int
+   , _relativeBase :: {-# unpack #-} !Int
+   , _currVector   :: !(V.Vector Int)
+   } deriving (Eq,Show,Read)
+   
+data ReadOrWrite = Read | Write deriving (Eq,Ord,Show,Enum,Bounded)
+data ParameterMode = Position | Immediate | Relative
+     deriving (Eq,Ord,Show,Enum,Bounded)
+
+readParameterMode :: Int -> ParameterMode
+readParameterMode 0 = Position
+readParameterMode 1 = Immediate
+readParameterMode 2 = Relative
+readParameterMode n = error $ "Unrecognized ParameterMode: " ++ show n
+
+getVal :: ReadOrWrite -> ParameterMode -> Int -> State -> Int
+getVal rw pm i s = case (rw,pm) of 
+    (Read ,Position ) -> v ! (v ! i)
+    (Read ,Immediate) -> v ! i
+    (Read ,Relative ) -> v ! ((v ! i) + _relativeBase s)
+    (Write,Position ) -> v ! i
+    (Write,Relative ) -> (v ! i) + _relativeBase s
+    where
+    v = _currVector s
+    (!) :: V.Vector Int -> Int -> Int
+    (!) v' i' = fromMaybe 0 $ v' V.!? i'
+
+data Opcode =
+     Add    !ParameterMode !ParameterMode !ParameterMode
+   | Mult   !ParameterMode !ParameterMode !ParameterMode
+   | Stop
+   | Input  !ParameterMode
+   | Output !ParameterMode
+   | JumpIfTrue  !ParameterMode !ParameterMode 
+   | JumpIfFalse !ParameterMode !ParameterMode 
+   | LessThan    !ParameterMode !ParameterMode !ParameterMode
+   | Equals      !ParameterMode !ParameterMode !ParameterMode
+   | RelativeBaseOffset !ParameterMode
+     deriving (Eq,Ord,Show)
+
+readOpcode :: Int -> Opcode
+readOpcode n = case opc of
+    1  -> Add  a b c
+    2  -> Mult a b c
+    3  -> Input  a
+    4  -> Output a
+    5  -> JumpIfTrue  a b 
+    6  -> JumpIfFalse a b 
+    7  -> LessThan    a b c
+    8  -> Equals      a b c
+    9  -> RelativeBaseOffset a
+    99 -> Stop
+    _ -> error $ "Unrecognized Opcode: " ++ show n
+    where
+    (pms,opc) = n `divMod` 100
+    (r ,a) = readParameterMode <$> pms `divMod` 10
+    (r',b) = readParameterMode <$> r `divMod` 10
+    (_ ,c) = readParameterMode <$> r' `divMod` 10
+
+data PauseReason = 
+     Stopped 
+   | NeedsInput (Int -> State) 
+   | HasOutput (Int,State)
+   
+isStopped :: PauseReason -> Bool
+isStopped Stopped = True
+isStopped _ = False
+    
+runOp :: State -> Opcode -> Either PauseReason State
+runOp s = \case 
+    Add  p1 p2 p3 -> Right $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal Read  p1 (i+1) s
+            b = getVal Read  p2 (i+2) s
+            j = getVal Write p3 (i+3) s
+         in writeAt j (a + b)
+    Mult p1 p2 p3 -> Right $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal Read  p1 (i+1) s
+            b = getVal Read  p2 (i+2) s
+            j = getVal Write p3 (i+3) s
+         in writeAt j (a * b)
+    JumpIfTrue p1 p2 -> Right $ s & nextIndex %~ 
+        let a = getVal Read p1 (i+1) s
+            b = getVal Read p2 (i+2) s
+         in if a /= 0 then const b else (+3)
+    JumpIfFalse p1 p2 -> Right $ s & nextIndex %~ 
+        let a = getVal Read p1 (i+1) s
+            b = getVal Read p2 (i+2) s
+         in if a == 0 then const b else (+3)
+    LessThan p1 p2 p3 -> Right $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal Read p1 (i+1) s
+            b = getVal Read p2 (i+2) s
+            j = getVal Write p3 (i+3) s
+         in writeAt j (if a < b then 1 else 0)
+    Equals p1 p2 p3 -> Right $ s & nextIndex %~ (+4) & currVector %~ 
+        let a = getVal Read p1 (i+1) s
+            b = getVal Read p2 (i+2) s
+            j = getVal Write p3 (i+3) s
+         in writeAt j (if a == b then 1 else 0)
+    RelativeBaseOffset p1 -> Right $ s & nextIndex %~ (+2) & relativeBase %~ (+getVal Read p1 (i+1) s)
+    Input p1 -> Left $ NeedsInput $ \input -> 
+                s & nextIndex %~ (+2) & currVector %~ 
+                    let j = getVal Write p1 (i+1) s
+                     in writeAt j input
+    Output p1 -> Left $ HasOutput 
+                ( getVal Read p1 (i+1) s
+                , s & nextIndex %~ (+2)
+                )
+    Stop  -> Left Stopped
+    where
+    i = s ^. nextIndex
+    
+getOp :: State -> Opcode
+getOp s = readOpcode $ (s ^. currVector) V.! (s ^. nextIndex)
+   
+step :: State -> Either PauseReason State
+step s = runOp s $ getOp s
+
+runToPause :: State -> PauseReason
+runToPause = either id runToPause . step 
+    
+-- * Utils    
+writeAt :: Int -> Int -> V.Vector Int -> V.Vector Int
+writeAt i value initialV 
+    | i < l = V.modify (\vec -> VM.write vec i value) initialV
+    | value == 0 = initialV
+    | i == l = initialV `V.snoc` value
+    | otherwise = initialV V.++ (V.replicate (i-l) 0 `V.snoc` value)
+    where
+    l = V.length initialV
+
+iterateMaybe :: (a -> Maybe a) -> a -> [a]
+iterateMaybe f = fix $ \rec x -> x : maybe [] rec (f x)
+
+
+-- * Lenses
+-- :set -ddump-splices
+-- makeLenses ''State
+
+currVector :: Lens' State (V.Vector Int)
+currVector f_aK6I (State x1_aK6J x2_aK6K x3_aK6L)
+  = (fmap (\ y1_aK6M -> ((State x1_aK6J) x2_aK6K) y1_aK6M))
+      (f_aK6I x3_aK6L)
+{-# INLINE currVector #-}
+nextIndex :: Lens' State Int
+nextIndex f_aK6N (State x1_aK6O x2_aK6P x3_aK6Q)
+  = (fmap (\ y1_aK6R -> ((State y1_aK6R) x2_aK6P) x3_aK6Q))
+      (f_aK6N x1_aK6O)
+{-# INLINE nextIndex #-}
+relativeBase :: Lens' State Int
+relativeBase f_aK6S (State x1_aK6T x2_aK6U x3_aK6V)
+  = (fmap (\ y1_aK6W -> ((State x1_aK6T) y1_aK6W) x3_aK6V))
+      (f_aK6S x2_aK6U)
+{-# INLINE relativeBase #-}


### PR DESCRIPTION
06 I think has some direct applicability, it's a good example of using reducers on generic ADTs. 

01 Just uses iterate/takeWhile, which is normal lazy fp
02, 05, 07, 09 all just those annoying intcode stuff. I guess that kinda is nice to show how to add functionality in haskell, but I don't know how much that progression might illuminate the clojure dev cycle. 
03 I just created sets/maps with every square you hit lol, not very elegant
04 was straightforward. Does illustrate how to generate a strictly increasing set of numbers with only the given digits, but w/e
08 illustrates that Haskell needs a better matrix library that is easy to compile on windows D: actually I think I have used one, but oh well. 